### PR TITLE
Update Governance.md

### DIFF
--- a/governance/Governance.md
+++ b/governance/Governance.md
@@ -6,11 +6,42 @@ This document provides the governance policy for specifications and other docume
 
 Each Working Group may include the following roles. Additional roles may be adopted and documented by the Working Group.
 
-**1.1.	Maintainer.** “Maintainers” are responsible for organizing activities around developing, maintaining, and updating the specification(s) developed by the Working Group.  Maintainers are also responsible for determining consensus and coordinating appeals.  Each Working Group will designate one or more Maintainer for that Working Group.  A Working Group may select a new or additional Maintainer(s) upon Approval of the Working Group Participants.  
+**1.1.	Maintainer.** "Maintainers" are responsible for organizing activities around developing, maintaining, and updating the specification(s) and other assets developed by the Project. Maintainers are also responsible for determining consensus and coordinating appeals. Examples of the responsibility of a Maintainer (directly or by delegation) include:
+
+<li> leading workstream meetings and tracking progress
+<li> setting the agenda, scheduling meetings and keeping minutes
+<li> actively engaging with the proposals process, both in GitHub issues and the slsa-proposals repo
+<li> triaging and prioritizing issues
+<li> contributing and reviewing pull requests
+<li> manage the day-to-day planning, operation, organization, deliverables and alignment with other workstreams
+<li> coordinating efforts with the Steering Committee, other workstreams and other external projects
+<li> ensuring that the contents of their workstream's materials accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines
+
+A Contributor may become a Maintainer with the Approval of the Steering Committee. A Maintainer may be removed with the Approval of the Steering Committee. A Steering Committee Member may not deliberate or vote on their own appointment or removal as a Maintainer.  
 
 **1.2.	Editor.**  “Editors” are responsible for ensuring that the contents of the document accurately reflect the decisions that have been made by the group, and that the specification adheres to formatting and content guidelines. Each Working Group will designate an Editor for that Working Group.  A Working Group may select a new Editor upon Approval of the Working Group Participants.
 
 **1.3.	Participants.**  “Participants” are those that have made Contributions to the Working Group subject to the Community Specification License.
+
+**1.4. Steering Committee Members.** The "Steering Committee" is the body that is responsible for overseeing the overall activities of the Project. The Steering Committee consists of up to 7 Participants (each, a "Steering Committee Member") and will initially consist of the Steering Committee Members so designated as of the date of initial adoption of this S2C2F Governance Policy. The Steering Committee will meet regularly as needed, but no less then once per quarter. Examples of the responsibilities of the Steering Committee include:
+
+<li> enabling the smooth running of the Project
+<li> coordinating activities between workstreams and Maintainers
+<li> collectively reviewing and revising the roadmap on a biannual basis
+<li> participating in strategic planning, such as coordinating face-to-face meetings or suggesting and approving changes to the governance model
+<li> creating or restructuring workstreams
+<li> responding to specific issues or concerns above and beyond the domain of the various workstreams
+<li> making decisions when community consensus cannot be reached, pursuant to the appeal process documented below
+
+**1.5. Steering Committee Member Terms.** During the initial year, the Steering Committee Members will agree on grouping themselves into two groups, one to serve an initial two-year term, and the other for an initial one-year term. Thereafter, the Steering Committee Members will serve two year terms.
+
+At the expiration of a Steering Committee Member term, any Participant may submit a nomination to fill the seat. An individual may be nominated for and serve any number of successive terms.
+
+If a Steering Committee Member resigns or ceases to participate for a significant period of time prior to the end of their term, the remaining Steering Committee Members may choose to remove that Steering Committee Member. If so, the remaining Steering Committee Members will determine whether and when to fill the role.
+
+The Steering Committee may add additional Steering Committee Members as it deems necessary.
+
+After discussion with the nominees for a vacant seat, the Steering Committee will select the new Steering Committee Members from the group of nominees taking into account such things as the nominees’ willingness to take on the role, skills, and level of participation as well as the need to maintain a balanced perspective on the Steering Committee (e.g., no more than two people from the same group of related companies should be on the Steering Committee). A Steering Committee Member nominee may not deliberate or vote on their own appointment.
 
 ## 2.	Decision Making.
 
@@ -18,6 +49,10 @@ Each Working Group may include the following roles. Additional roles may be adop
 
 **2.2.	Appeal Process.**  Decisions may be appealed be via a pull request or an issue, and that appeal will be considered by the Maintainer in good faith, who will respond in writing within a reasonable time.
 
+**2.3. Steering Committee Appeal Process.** Decisions that have been appealed to the Maintainers may in extraordinary cases be appealed to the Steering Committee for reconsideration. An appeal to the Steering Committee must specify in detail (1) the specific decision that is being appealed; (2) the basis for contending that the decision was not aligned with the purposes, goals or scope of the Project; and (3) an explanation of why the decision is extraordinary enough to warrant an appeal to the Steering Committee. The appeal will be considered by the Steering Committee in good faith, who will respond in writing within a reasonable time. The Steering Committee may decline to consider appeals that are unexceptional, unfounded or excessive, including because of their repetitive character.
+
+**2.4. Amendments to Governance Documents.** The documents in this Governance repository may be amended by a two-thirds vote of the entire Steering Committee and are subject to approval by The Linux Foundation. However, entries may be added to the Notices file in this Governance repository as described therein.
+  
 ## 3.	Ways of Working.
 
 Inspired by [ANSI’s Essential Requirements for Due Process](https://share.ansi.org/Shared%20Documents/Standards%20Activities/American%20National%20Standards/Procedures,%20Guides,%20and%20Forms/2020_ANSI_Essential_Requirements.pdf), Community Specification Working Groups must adhere to consensus-based due process requirements.  These requirements apply to activities related to the development of consensus for approval, revision, reaffirmation, and withdrawal of Community Specifications.  Due process means that any person (organization, company, government agency, individual, etc.) with a direct and material interest has a right to participate by: a) expressing a position and its basis, b) having that position considered, and c) having the right to appeal. Due process allows for equity and fair play. The following constitute the minimum acceptable due process requirements for the development of consensus.
@@ -36,15 +71,19 @@ Inspired by [ANSI’s Essential Requirements for Due Process](https://share.ansi
 
 ## 4.	Specification Development Process.  
 
-**4.1.	Pre-Draft.**  Any Participant may submit a proposed initial draft document as a candidate Draft Specification of that Working Group.  The Maintainer will designate each submission as a “Pre-Draft” document.
+**4.1. Draft.** During the specification development process, Participants may submit issues and pull requests to a S2C2F specification repository. Pull requests will be merged upon Approval of the applicable Maintainers. Each updated version of the specification following the merging of a pull request will be considered a "Draft Specification".
 
-**4.2.	Draft.**  Each Pre-Draft document of a Working Group must first be Approved to become a” Draft Specification”.  Once the Working Group approves a document as a Draft Specification, the Draft Specification becomes the basis for all going forward work on that specification.
+**4.2.** Project Approval. Upon the determination by the applicable workstream that it has achieved the objectives for its specification as described in the Scope, the applicable Maintainers will Approve that Draft Specification as a candidate for "Approved Specification" status. The following process will then be used:
 
-**4.3.	Working Group Approval.**  Once a Working Group believes it has achieved the objectives for its specification as described in the Scope, it will Approve that Draft Specification and progress it to “Approved Specification” status. 
+<li> The Maintainers will distribute that version of the Draft Specification to the Project's primary mailing list.
+<li> The Maintainers will state in the distribution that the Draft Specification is a candidate for "Approved Specification" status, and will announce the start of a two-week review period (the "Review Period").
+<li> During the Review Period, Participants may raise any issues regarding the Draft Specification. Such issues will be considered and resolved in the ordinary course.
+<li> The Maintainers may, in their discretion, extend the Review Period for a longer period of time, but will not shorten it to be less than the initial two-week period.
+<li> After the completion of the Review Period and upon the Approval of the Project (which may include the absence of, or resolution in the ordinary course of, any issues raised during the Review Period), the Draft Specification will be progressed to be an "Approved Specification".
+  
+**4.3. Publication and Submission.** Upon the designation of a Draft Specification as an Approved Specification, the Maintainers will publish the Approved Specification in a manner agreed upon by the Project Participants (i.e., Project Participant only location, publicly available location, Project maintained website, Project member website, etc.). The publication of an Approved Specification in a publicly accessible manner must include the terms under which the Approved Specification is being made available.
 
-**4.4.	Publication and Submission.**  Upon the designation of a Draft Specification as an Approved Specification, the Maintainer will publish the Approved Specification in a manner agreed upon by the Working Group Participants (i.e., Working Group Participant only location, publicly available location, Working Group maintained website, Working Group member website, etc.).  The publication of an Approved Specification in a publicly accessible manner must include the terms under which the Approved Specification is being made available under.
-
-**4.5.	Submissions to Standards Bodies.**  No Draft Specification or Approved Specification may be submitted to another standards development organization without Working group Approval. Upon reaching Approval, the Maintainer will coordinate the submission of the applicable Draft Specification or Approved Specification to another standards development organization. Working Group Participants that developed that Draft Specification or Approved Specification agree to grant the copyright rights necessary to make those submissions.
+**4.4. Submissions to Standards Bodies.** No Draft Specification or Approved Specification may be submitted to another standards development organization without Project Approval. Upon reaching Approval, the Maintainers will coordinate the submission of the applicable Draft Specification or Approved Specification to another standards development organization. The Project Participants that developed that Draft Specification or Approved Specification agree to grant the copyright rights necessary to make those submissions.
 
 ## 5. Non-Confidential, Restricted Disclosure.
 


### PR DESCRIPTION
Updated Governance to clearly delineate the difference between Maintainers and Steering Committee members. 

Made a few other changes to align with other OpenSSF projects.

Signed-off-by: Adrian Diglio <55258689+adriandiglio@users.noreply.github.com>