### PR TITLE
Fixing broken link to spec in README

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -2,7 +2,7 @@
 
 > ⭐: **Click _[here](Secure_Supply_Chain_Consumption_Framework_(S2C2F).pdf)_ for the PDF of the specification**
 > 
-> :atom:: **Click _[here](specification/framework.md)_ to view the specification in markdown**
+> :atom:: **Click _[here](framework.md)_ to view the specification in markdown**
 
 ## Updates to the specification
 


### PR DESCRIPTION
Fixing a broken link from a README to the specification.