### PR TITLE
Change SIG to Project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Secure Supply Chain Consumption Framework (S2C2F) SIG
+# Secure Supply Chain Consumption Framework (S2C2F) Project
 
 <img alt="secure package icon" src="images/secure-package-icon.png" width=15%>
 
-The S2C2F SIG is a group working within the OpenSSF's Supply Chain Integrity Working Group formed to further develop and continuously improve the S2C2F guide which outlines and defines how to securely consume Open Source Software (OSS) dependencies into the developer’s workflow. This paper is split into two parts: a solution-agonistic set of practices and a maturity model-based implementation guide. The Framework is targeted toward organizations that do software development, that take a dependency on open source software, and that seek to improve the security of their software supply chain.
+The S2C2F Project is a group working within the OpenSSF's Supply Chain Integrity Working Group formed to further develop and continuously improve the S2C2F guide which outlines and defines how to securely consume Open Source Software (OSS) dependencies into the developer’s workflow. This paper is split into two parts: a solution-agonistic set of practices and a maturity model-based implementation guide. The Framework is targeted toward organizations that do software development, that take a dependency on open source software, and that seek to improve the security of their software supply chain.
 
 ## Motivation
 
@@ -10,7 +10,7 @@ OSS has become a critical aspect of any software supply chain. The S2C2F was des
 
 ## Objective
 
-The objective for the S2C2F SIG is to develop and continuously improve upon a guide that provides the following:
+The objective for the S2C2F Project is to develop and continuously improve upon a guide that provides the following:
 
 * A high-level solution-agnostic set of practices 
 * A detailed list of requirements 
@@ -32,7 +32,7 @@ To learn more, the S2C2F FAQ is available [here](./FAQ.md).
 
 *   Official communications occur on the [openssf-sig-s2c2f@lists.openssf.org](https://lists.openssf.org/g/openssf-sig-s2c2f).  \
 [Manage your subscriptions to Open SSF mailing lists](https://lists.openssf.org/g/main/subgroups).
-*   [S2C2F SIG Slack](https://openssf.slack.com/archives/C03THTH3RSM)
+*   [S2C2F Project Slack](https://openssf.slack.com/archives/C03THTH3RSM)
 *   [Supply Chain Integrity WG Slack](https://openssf.slack.com/archives/C01A1MA7A1K)
 
 ### Quick Start
@@ -52,12 +52,12 @@ The [GOVERNANCE.md](https://github.com/ossf/s2c2f/blob/main/governance/Governanc
 *   Lead: Adrian Diglio (https://github.com/adriandiglio)
 *   Co-Lead: Jay White (https://github.com/camaleon2016)
 
-## SIG Maintainers
+## Project Maintainers
 - [Jay White, Microsoft](https://github.com/camaleon2016)
 - [Adrian Diglio, Microsoft](https://github.com/adriandiglio)
 - [Jasmine Wang, Microsoft](https://github.com/jasminewang0)
 
 
-## SIG Collaborators
+## Project Collaborators
 - [Christopher "CRob" Robinson, Intel](https://github.com/SecurityCRob)
 - [David A Wheeler, LF/OSSF](https://github.com/david-a-wheeler)


### PR DESCRIPTION
The OpenSSF governance structure now provides for specification development work to take place in Projects rather than SIGs (see [TAC PR#225](https://github.com/ossf/tac/pull/225)). The mailing list will need to be renamed accordingly.
